### PR TITLE
LaTex support

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 ---
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 
 {% if page.image and page.headerImage %}
     <img class="title-image" src="{{ page.image }}" alt="{{ page.title }}">


### PR DESCRIPTION
## Description
Add this line to enable LaTex support.

## Why open the pull request
Many people on Github are programmers who sometimes need to type math formulas, it would be great if the current template supports LaTex.

## Effect after change
Example:

$$ Q(s_t, a_t) = Q(s_t, a_t) + \alpha(r_t + \gamma \mathop{max}\limits_aQ(s_{t+1}, a) - Q(s_t, a_t)) $$

=>

<img width="466" alt="Screen Shot 2021-04-02 at 11 30 53 PM" src="https://user-images.githubusercontent.com/19467235/113470577-79908e80-940b-11eb-960b-3920958331ee.png">
